### PR TITLE
Add operation support to Capability Statement

### DIFF
--- a/FhirServer/Metadata.js
+++ b/FhirServer/Metadata.js
@@ -162,6 +162,14 @@ const Server = {
         CapabilityStatement.rest[0].resource.push(newResourceStatement);
       })
     }
+
+    if (Array.isArray(Meteor, 'settings.private.fhir.operation')) {
+      CapabilityStatement.operation = [];
+      Meteor.settings.private.fhir.operation.forEach(function(op){
+        CapabilityStatement.operation.push(op);
+      });
+    }
+
     return CapabilityStatement;
   },
   getWellKnownSmartConfiguration: function(){

--- a/FhirServer/Metadata.js
+++ b/FhirServer/Metadata.js
@@ -133,9 +133,9 @@ const Server = {
 
         if (Array.isArray(Meteor.settings.private.fhir.rest[key].operation)) {
           newResourceStatement.operation = [];
-          Meteor.settings.private.fhir.rest[key].operation.forEach(function(op)){
+          Meteor.settings.private.fhir.rest[key].operation.forEach(function(op){
             newResourceStatement.operation.push(op);
-          }
+          });
         }
 
         if (Array.isArray(Meteor.settings.private.fhir.rest[key].interactions)) {

--- a/FhirServer/Metadata.js
+++ b/FhirServer/Metadata.js
@@ -131,9 +131,9 @@ const Server = {
           // "searchParam": defaultSearchParams
         }
 
-        if (Array.isArray(Meteor.settings.private.fhir.rest[key].operation)) {
+        if (Array.isArray(Meteor.settings.private.fhir.rest[key].operations)) {
           newResourceStatement.operation = [];
-          Meteor.settings.private.fhir.rest[key].operation.forEach(function(op){
+          Meteor.settings.private.fhir.rest[key].operations.forEach(function(op){
             newResourceStatement.operation.push(op);
           });
         }
@@ -163,10 +163,10 @@ const Server = {
       })
     }
 
-    if (Array.isArray(Meteor, 'settings.private.fhir.operation')) {
-      CapabilityStatement.operation = [];
-      Meteor.settings.private.fhir.operation.forEach(function(op){
-        CapabilityStatement.operation.push(op);
+    if (Array.isArray(Meteor.settings.private.fhir.systemOperations)) {
+      CapabilityStatement.rest[0].operation = [];
+      Meteor.settings.private.fhir.systemOperations.forEach(function(op){
+        CapabilityStatement.rest[0].operation.push(op);
       });
     }
 

--- a/FhirServer/Metadata.js
+++ b/FhirServer/Metadata.js
@@ -121,12 +121,6 @@ const Server = {
       Object.keys(Meteor.settings.private.fhir.rest).forEach(function(key){
         let newResourceStatement = {
           "type": key,
-          "operation": [
-            {
-                "name": "$match",
-                "definition": "http://hl7.org/fhir/OperationDefinition/Patient-match"
-            }
-          ],
           "interaction": defaultInteractions,
           // "versioning": "no-version"
           // "readHistory": false,
@@ -135,6 +129,13 @@ const Server = {
           // "conditionalUpdate": false,
           // "conditionalDelete": "not-supported"
           // "searchParam": defaultSearchParams
+        }
+
+        if (Array.isArray(Meteor.settings.private.fhir.rest[key].operation)) {
+          newResourceStatement.operation = [];
+          Meteor.settings.private.fhir.rest[key].operation.forEach(function(op)){
+            newResourceStatement.operation.push(op);
+          }
         }
 
         if (Array.isArray(Meteor.settings.private.fhir.rest[key].interactions)) {
@@ -259,7 +260,7 @@ Meteor.startup(function() {
     if(process.env.TRACE){
       console.log('return payload', returnPayload);
     }
-   
+
     JsonRoutes.sendResult(res, returnPayload);
   });
 
@@ -276,7 +277,7 @@ Meteor.startup(function() {
     if(process.env.TRACE){
       console.log('return payload', returnPayload);
     }
-   
+
     JsonRoutes.sendResult(res, returnPayload);
   });
 
@@ -296,7 +297,7 @@ Meteor.startup(function() {
     if(process.env.TRACE){
       console.log('return payload', returnPayload);
     }
-   
+
     JsonRoutes.sendResult(res, returnPayload);
   });
 
@@ -315,7 +316,7 @@ Meteor.startup(function() {
     if(process.env.TRACE){
       console.log('return payload', returnPayload);
     }
-   
+
     JsonRoutes.sendResult(res, returnPayload);
   });
 
@@ -334,7 +335,7 @@ Meteor.startup(function() {
     if(process.env.TRACE){
       console.log('return payload', returnPayload);
     }
-   
+
     JsonRoutes.sendResult(res, returnPayload);
   });
 

--- a/FhirServer/Metadata.js
+++ b/FhirServer/Metadata.js
@@ -90,15 +90,15 @@ const Server = {
         "extension": [
           {
             "url": "token",
-            "valueUri": Meteor.absoluteUrl() + get(Meteor, 'settings.private.fhir.security.tokenEndpoint', "oauth/token") 
+            "valueUri": Meteor.absoluteUrl() + get(Meteor, 'settings.private.fhir.security.tokenEndpoint', "oauth/token")
           },
           {
             "url": "authorize",
-            "valueUri": Meteor.absoluteUrl() + get(Meteor, 'settings.private.fhir.security.authorizationEndpoint', "oauth/authorize") 
+            "valueUri": Meteor.absoluteUrl() + get(Meteor, 'settings.private.fhir.security.authorizationEndpoint', "oauth/authorize")
           },
           {
             "url": "register",
-            "valueUri": Meteor.absoluteUrl() + get(Meteor, 'settings.private.fhir.security.registrationEndpoint', "oauth/registration") 
+            "valueUri": Meteor.absoluteUrl() + get(Meteor, 'settings.private.fhir.security.registrationEndpoint', "oauth/registration")
           },
           {
             "url": "manage",
@@ -116,11 +116,17 @@ const Server = {
         "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"
       })
     }
-    
+
     if (has(Meteor, 'settings.private.fhir.rest')) {
       Object.keys(Meteor.settings.private.fhir.rest).forEach(function(key){
         let newResourceStatement = {
           "type": key,
+          "operation": [
+            {
+                "name": "$match",
+                "definition": "http://hl7.org/fhir/OperationDefinition/Patient-match"
+            }
+          ],
           "interaction": defaultInteractions,
           // "versioning": "no-version"
           // "readHistory": false,
@@ -153,14 +159,14 @@ const Server = {
 
 
         CapabilityStatement.rest[0].resource.push(newResourceStatement);
-      })      
+      })
     }
     return CapabilityStatement;
   },
   getWellKnownSmartConfiguration: function(){
     let response = {
       "resourceType": "Basic",
-      
+
       // required fields
       "authorization_endpoint": Meteor.absoluteUrl() + get(Meteor, 'settings.private.fhir.security.authorizationEndpoint', "oauth/authorize"),
       "token_endpoint":  Meteor.absoluteUrl() + get(Meteor, 'settings.private.fhir.security.tokenEndpoint', "oauth/token") ,
@@ -185,7 +191,7 @@ const Server = {
   getWellKnownUdapConfiguration: function(){
     let response = {
       "resourceType": "UdapMetadata",
-      "x5c": [],      
+      "x5c": [],
       "udap_versions_supported": ["1"],
       "udap_certifications_supported": ["https://vhdir.meteorapp.com/udap/profiles/example-certification"],
       "udap_certifications_required": ["https://vhdir.meteorapp.com/udap/profiles/example-certification"],
@@ -214,7 +220,7 @@ const Server = {
       "udap_profiles_supported": ["udap_authz", "udap_dcr"],
       "udap_authorization_extensions_supported": [],
       "udap_authorization_extensions_required": [],
-      "signed_endpoints": []      
+      "signed_endpoints": []
     }
 
     let fhirRestEndpoints = get(Meteor, 'settings.private.fhir.rest');


### PR DESCRIPTION
PR lets you add resource-level and system-level operations from the config file. I.e. A (shortened) settings file such as:
```json
{
  ...
  "private": {
    "fhir": {
      "fhirPath": "baseR4",
      "rest": {
        "Patient": {
          "interactions": ["read", "create", "update", "delete"],
          "operations": [
            {
              "name": "$match",
              "definition": "http://hl7.org/fhir/OperationDefinition/Patient-match"
            }
          ]
        }
      },
      "systemOperations": [
        {
            "name": "$not-real-system-operation",
            "definition": "http://example.com/fhir/test-for-system-operations"
        }
      ]
    }
  }
}
```

which will yield the (shortened) capability statement:
```json
{
  "resourceType": "CapabilityStatement",
  "url": "http://localhost:3000/baseR4",
  ...
  "rest": [
    {
      "mode": "server",
      "resource": [
        {
          "type": "Patient",
          "interaction": [
            {
              "code": "read"
            },
            {
              "code": "create"
            },
            {
              "code": "update"
            },
            {
              "code": "delete"
            }
          ],
          "operation": [
            {
              "name": "$match",
              "definition": "http://hl7.org/fhir/OperationDefinition/Patient-match"
            }
          ],
          "versioning": "no-version"
        }
      ],
      ...
      "operation": [
        {
          "name": "$not-real-system-operation",
          "definition": "http://example.com/fhir/test-for-system-operations"
        }
      ]
    }
  ]
}
```